### PR TITLE
test(subprocess): treat ESRCH as gone in waitGone

### DIFF
--- a/packages/subprocess/subprocess-local/tests/spawn.spec.ts
+++ b/packages/subprocess/subprocess-local/tests/spawn.spec.ts
@@ -75,7 +75,9 @@ async function waitGone(pid: number, timeoutMs = 5_000): Promise<void> {
         const state = stat.slice(stat.lastIndexOf(')') + 2, stat.lastIndexOf(')') + 3)
         if (state === 'Z' || state === 'X') return
       } catch (error: unknown) {
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+        // ESRCH = the pid vanished between the kill-0 probe and this read,
+        // which is the same terminal state ENOENT reports on a settled entry.
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT' || (error as NodeJS.ErrnoException).code === 'ESRCH') return
         throw error
       }
     }


### PR DESCRIPTION
A pid can exit between the kill-0 probe and the /proc read; readFileSync then reports ESRCH, which is the same terminal state the ENOENT arm already accepts. The loaded coverage lane hit this race on the master push run.

<!-- 写 Fixes #NN 表示解决并自动关闭；写 Related to #NN 仅关联。 -->
<!-- 进入评审的非 Draft 人类 PR 至少引用一个同仓库 Issue。 -->
<!-- 解决型 PR 与 Issue 同步 Priority；解决多个 Issue 时取最高值。 -->

关联 Issue：

<details>
<summary>变更与验证</summary>

- 变更：
- 验证：

</details>
